### PR TITLE
Small Fixes

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -8,5 +8,5 @@
     "username": "", 
     "password": "",
     "enrollment_location_id": "",
-    "init_url": "https://goes-app.cbp.dhs.gov/main/goes",
+    "init_url": "https://goes-app.cbp.dhs.gov/main/goes"
 }

--- a/ge-cancellation-checker.phantom.js
+++ b/ge-cancellation-checker.phantom.js
@@ -154,7 +154,9 @@ var steps = [
 
             document.querySelector('select[name=selectedEnrollmentCenter]').value = location_id;
             fireClick(document.querySelector('input[name=next]'));
-            console.log('Choosing SFO...');
+
+            var location_name = document.querySelector('option[value="' + location_id + '"]').text;
+            console.log('Choosing Location: ' + location_name);
         }, settings.enrollment_location_id.toString());
     },
     function() {


### PR DESCRIPTION
- Remove the trailing coma from the config.json example
- Print out the correct location instead of a hard-coded one when running the phantomjs script in verbose mode
